### PR TITLE
delete inline specification

### DIFF
--- a/dlist.h
+++ b/dlist.h
@@ -23,7 +23,7 @@
     struct dlist_element_##typename
 
 #define dlist_pop_decl(type, typename) \
-inline type dlist_##typename##_pop( dlist(typename)* list ) { \
+type dlist_##typename##_pop( dlist(typename)* list ) { \
     dlist_element(typename) *element = list->tail; \
     list->tail = list->tail->prev; \
     type retval = element->data; \
@@ -33,7 +33,7 @@ inline type dlist_##typename##_pop( dlist(typename)* list ) { \
 }
 
 #define dlist_unshift_decl(type, typename) \
-inline type dlist_##typename##_unshift( dlist(typename)* list ) { \
+type dlist_##typename##_unshift( dlist(typename)* list ) { \
     dlist_element(typename) *element = list->head; \
     list->head = list->head->next; \
     dlistel_break(element); \


### PR DESCRIPTION
Test Environment

1. `4.9.73-1-MANJARO #1 SMP PREEMPT UTC 2017 x86_64 GNU/Linux`
2. `gcc version 7.2.1 20171224 (GCC) `

For now, the source code will occurs the following error.

```
/tmp/ccAnRR2f.o: In function `main':
/home/gapry/Workspaces/tmp/dlist/test.c:34: undefined reference to `dlist_int_pop'
/home/gapry/Workspaces/tmp/dlist/test.c:38: undefined reference to `dlist_int_unshift'
collect2: error: ld returned 1 exit status
make: *** [makefile:6: test] Error  
```

Since `inline type dlist_##typename##_pop( dlist(typename)* list )` will generate instructions in place and doesn't give a label for the routine. Hence, the caller can't reference the callee.
